### PR TITLE
use as plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,26 @@ REST APIs for c-lightning written in Node.js
 `$ npm install`
 
 ### Config params
-Currently three params are supported to be configured at run time in the config file `cl-rest-config.json`.
-Rename the file `sample-cl-rest-config.json` to `cl-rest-config.json`.
+Currently three params are supported to be configured at run time in the config file `cl-rest-config.json` or as part of the plugin configuration if used as a plugin.
+
+For running the server, rename the file `sample-cl-rest-config.json` to `cl-rest-config.json`.
 - PORT (Default: `3001`)
 - PROTOCOL (Default: `https`) - Two options are supported `https` and `http`(unencrypted and insecure communication between c-lightning and API server).
 - EXECMODE (Default: `production`) - Control for more detailed log info.
 
-### Execute
+For running as a plugin, use the options, `rest-port`, `rest-protocol` and `rest-execmode` in your c-lightning configuration, defaults are the same as above.
+
+### Execute Server
 - Run the API server
 `$ node cl-rest.js`
 Access the APIs on the default port 3001 or the port configured in the config file.
+
+### Run as plugin
+- Pass arguments when launching lightningd - `$ lightningd --plugin=PATH_TO_PLUGIN [--rest-port=N] [--rest-protocol=http|https] [--rest-execmode=MODE]`
+
+OR
+
+- Set `plugin`, `[rest-port]`, `[rest-protocol]`, and `[rest-execmode]` in lightningd [config](https://github.com/ElementsProject/lightning/blob/master/doc/lightningd-config.5.md)
 
 ### Security
 APIs will be served over https (a self signed certificate and key will be generated in the certs folder with openssl)

--- a/app.js
+++ b/app.js
@@ -2,8 +2,19 @@ const app = require('express')();
 const bodyparser = require('body-parser');
 
 //LN_PATH is the path containing lightning-rpc file
+if (typeof global.REST_PLUGIN_CONFIG === 'undefined') {
+  global.logger = console
+} else {
+  function pluginMsg(msg) {
+    return typeof msg === 'string' ? msg : JSON.stringify(msg)
+  }
+  global.logger = {
+    log(msg) {global.REST_PLUGIN_CONFIG.PLUGIN.log(pluginMsg(msg))},
+    warn(msg) {global.REST_PLUGIN_CONFIG.PLUGIN.log(pluginMsg(msg), "warn")},
+    error(msg) {global.REST_PLUGIN_CONFIG.PLUGIN.log(pluginMsg(msg), "error")}
+  }
+}
 global.ln = require('./lightning-client-js')(process.env.LN_PATH);
-
 app.use(bodyparser.json());
 app.use(bodyparser.urlencoded({extended: false}));
 app.use((req, res, next) => {

--- a/controllers/channel.js
+++ b/controllers/channel.js
@@ -4,7 +4,7 @@
 //Invoke the 'fundchannel' command to open a channel with a peer
 //Arguments - Pub key (required), Amount in sats (required)
 exports.openChannel = (req,res) => {
-    console.log('fundchannel initiated...');
+    global.logger.log('fundchannel initiated...');
 
     function connFailed(err) { throw err }
     ln.on('error', connFailed);
@@ -24,10 +24,10 @@ exports.openChannel = (req,res) => {
         announce=announce,
         minconf=minconf,
         utxos=utxos).then(data => {
-        console.log('fundchannel success');
+        global.logger.log('fundchannel success');
         res.status(201).json(data);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);
@@ -37,7 +37,7 @@ exports.openChannel = (req,res) => {
 //Invoke the 'listpeers' command get the list of channels
 //Arguments - No arguments
 exports.listChannels = (req,res) => {
-    console.log('listChannels initiated...');
+    global.logger.log('listChannels initiated...');
 
     function connFailed(err) { throw err }
     ln.on('error', connFailed);
@@ -65,14 +65,14 @@ exports.listChannels = (req,res) => {
             return getAliasForPeer(chanData);
         })
         ).then(function(chanList) {
-            console.log('listChannels success');
+            global.logger.log('listChannels success');
             res.status(200).json(chanList);
         }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);
@@ -82,7 +82,7 @@ exports.listChannels = (req,res) => {
 //Invoke the 'setchannelfee' command update the fee policy of a channel
 //Arguments - Channel id (required), Base rate (optional), PPM rate (optional)
 exports.setChannelFee = (req,res) => {
-    console.log('setChannelfee initiated...');
+    global.logger.log('setChannelfee initiated...');
 
     function connFailed(err) { throw err }
     ln.on('error', connFailed);
@@ -94,10 +94,10 @@ exports.setChannelFee = (req,res) => {
 
     //Call the setchannelfee command with the params
     ln.setchannelfee(id, base, ppm).then(data => {
-        console.log('setChannelfee success');
+        global.logger.log('setChannelfee success');
         res.status(201).json(data);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);
@@ -107,7 +107,7 @@ exports.setChannelFee = (req,res) => {
 //Invoke the 'close' command to close a channel
 //Arguments - Channel id (required),  Unilateral Timeout in seconds (optional)
 exports.closeChannel = (req,res) => {
-    console.log('closeChannel initiated...');
+    global.logger.log('closeChannel initiated...');
 
     function connFailed(err) { throw err }
     ln.on('error', connFailed);
@@ -119,10 +119,10 @@ exports.closeChannel = (req,res) => {
 
     //Call the close command with the params
     ln.close(id,unilaterlaltimeout).then(data => {
-        console.log('closeChannel success');
+        global.logger.log('closeChannel success');
         res.status(202).json(data);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);
@@ -137,10 +137,10 @@ exports.listForwards = (req,res) => {
 
     //Call the listforwards command
     ln.listforwards().then(data => {
-        console.log('listforwards success');
+        global.logger.log('listforwards success');
         res.status(200).json(data.forwards);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);
@@ -153,8 +153,8 @@ getAliasForPeer = (peer) => {
             peer.alias = data.nodes[0] ? data.nodes[0].alias : '';
             resolve(peer);
         }).catch(err => {
-            console.warn('Node lookup for getpeer failed\n');
-            console.warn(err);
+            global.logger.warn('Node lookup for getpeer failed\n');
+            global.logger.warn(err);
             peer.alias = '';
             resolve(peer);
         });

--- a/controllers/getBalance.js
+++ b/controllers/getBalance.js
@@ -26,10 +26,10 @@ exports.getBalance = (req,res) => {
             confBalance: confBalance,
             unconfBalance: unconfBalance
         }
-        console.log('getBalance success');
+        global.logger.log('getBalance success');
         res.status(200).json(walBalance);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
 

--- a/controllers/getFees.js
+++ b/controllers/getFees.js
@@ -11,10 +11,10 @@ exports.getFees = (req,res) => {
     ln.getinfo().then(data => {
         const feeData = {
             feeCollected: data.msatoshi_fees_collected};
-        console.log('getFees success');
+        global.logger.log('getFees success');
         res.status(200).json(feeData);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);

--- a/controllers/getinfo.js
+++ b/controllers/getinfo.js
@@ -25,11 +25,11 @@ exports.getinfoRtl = (req,res) => {
             chains: [{chain:'bitcoin', network: data.network}],
             version: data.version
         };
-        console.log(getinfodata);
-        console.log('getinfoRtl success');
+        global.logger.log(getinfodata);
+        global.logger.log('getinfoRtl success');
         res.status(200).json(getinfodata);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);
@@ -44,11 +44,11 @@ exports.getinfo = (req,res) => {
 
     //Call the getinfo command
     ln.getinfo().then(data => {
-        console.log(data);
-        console.log('getinfo success');
+        global.logger.log(data);
+        global.logger.log('getinfo success');
         res.status(200).json(data);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);

--- a/controllers/invoice.js
+++ b/controllers/invoice.js
@@ -24,11 +24,11 @@ exports.genInvoice = (req,res) => {
     fallback=fallback,
     preimage=preimage,
     exposeprivatechannels=exposePvt).then(data => {
-        console.log('bolt11 -> '+ data.bolt11);
-        console.log('genInvoice success');
+        global.logger.log('bolt11 -> '+ data.bolt11);
+        global.logger.log('genInvoice success');
         res.status(201).json(data);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);
@@ -47,11 +47,11 @@ exports.listInvoice = (req,res) => {
         //Call the listinvoice command with label
         ln.listinvoices(req.query.label).then(data => {
             if(Object.keys(data.invoices).length)
-                console.log('bolt11 -> '+ data.invoices[0].bolt11);
-            console.log('listInvoice success');
+                global.logger.log('bolt11 -> '+ data.invoices[0].bolt11);
+            global.logger.log('listInvoice success');
             res.status(200).json(data);
         }).catch(err => {
-            console.warn(err);
+            global.logger.warn(err);
             res.status(500).json({error: err});
         });
     }
@@ -59,11 +59,11 @@ exports.listInvoice = (req,res) => {
     {
         //Call the listinvoice command
         ln.listinvoices().then(data => {
-            console.log('Number of Invoices -> '+ Object.keys(data.invoices).length);
-            console.log('listInvoice success');
+            global.logger.log('Number of Invoices -> '+ Object.keys(data.invoices).length);
+            global.logger.log('listInvoice success');
             res.status(200).json(data);
         }).catch(err => {
-            console.warn(err);
+            global.logger.warn(err);
             res.status(500).json({error: err});
         });
     }
@@ -84,7 +84,7 @@ exports.delExpiredInvoice = (req,res) => {
         ln.delexpiredinvoice(req.query.maxexpiry).then(data => {
             res.status(202).json(data);
         }).catch(err => {
-            console.warn(err);
+            global.logger.warn(err);
             res.status(500).json({error: err});
         });
     }
@@ -92,10 +92,10 @@ exports.delExpiredInvoice = (req,res) => {
     {
         //Call the delexpiredinvoice command
         ln.delexpiredinvoice().then(data => {
-            console.log('delExpiredInvoice success');
+            global.logger.log('delExpiredInvoice success');
             res.status(202).json(data);
         }).catch(err => {
-            console.warn(err);
+            global.logger.warn(err);
             res.status(500).json({error: err});
         });
     }

--- a/controllers/listfunds.js
+++ b/controllers/listfunds.js
@@ -9,11 +9,11 @@ exports.listFunds = (req,res) => {
 
     //Call the listfunds command
     ln.listfunds().then(data => {
-        console.log(data);
-        console.log('listFunds success');
+        global.logger.log(data);
+        global.logger.log('listFunds success');
         res.status(200).json(data);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);

--- a/controllers/localRemoteBal.js
+++ b/controllers/localRemoteBal.js
@@ -17,16 +17,16 @@ exports.localRemoteBal = (req,res) => {
             localBalance = localBalance + chanArray[i].channel_sat;
             remoteBalance = remoteBalance + (chanArray[i].channel_total_sat - chanArray[i].channel_sat);
         }
-        console.log('localbalance -> ' + localBalance);
-        console.log('remotebalance -> ' + remoteBalance);
+        global.logger.log('localbalance -> ' + localBalance);
+        global.logger.log('remotebalance -> ' + remoteBalance);
         const lclRmtBal = {
             localBalance: localBalance,
             remoteBalance: remoteBalance
         }
-        console.log('localRemoteBal success');
+        global.logger.log('localRemoteBal success');
         res.status(200).json(lclRmtBal);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);

--- a/controllers/network.js
+++ b/controllers/network.js
@@ -22,7 +22,7 @@ exports.getRoute = (req,res) => {
         ).then(function(values) {
             res.status(200).json(values);
           }).catch(err => {
-            console.error(err.error);
+            global.logger.error(err.error);
           });
         });
     ln.removeListener('error', connFailed);
@@ -35,8 +35,8 @@ getAliasForRoute = (singleroute) => {
             singleroute.alias = data.nodes[0].alias;
             resolve(singleroute);
         }).catch(err => {
-            console.warn('Node lookup for getroute failed\n');
-            console.warn(err);
+            global.logger.warn('Node lookup for getroute failed\n');
+            global.logger.warn(err);
             singleroute.alias = '';
             resolve(singleroute);
         });
@@ -52,10 +52,10 @@ exports.listNode = (req,res) => {
 
     //Call the listnodes command with the params
     ln.listnodes(req.params.pubKey).then(data => {
-        console.log('listnodes success');
+        global.logger.log('listnodes success');
         res.status(200).json(data.nodes);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);
@@ -70,10 +70,10 @@ exports.listChannel = (req,res) => {
 
     //Call the listchannels command with the params
     ln.listchannels(req.params.shortChanId).then(data => {
-        console.log('listchannels success');
+        global.logger.log('listchannels success');
         res.status(200).json(data.channels);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);
@@ -88,10 +88,10 @@ exports.feeRates = (req,res) => {
 
     //Call the listchannels command with the params
     ln.feerates(req.params.rateStyle).then(data => {
-        console.log('feerates success');
+        global.logger.log('feerates success');
         res.status(200).json(data);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);

--- a/controllers/newaddr.js
+++ b/controllers/newaddr.js
@@ -15,13 +15,13 @@ exports.newAddr = (req,res) => {
             addr = {address: data['p2sh-segwit']}
         else
             addr = {address: data.bech32}
-        console.log('address -> '+ addr.address);
+        global.logger.log('address -> '+ addr.address);
         res.status(200).json(addr);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
 
     ln.removeListener('error', connFailed);
-    console.log('newAddr success');
+    global.logger.log('newAddr success');
 }

--- a/controllers/payments.js
+++ b/controllers/payments.js
@@ -4,7 +4,7 @@
 //Invoke the 'pay' command to pay the bolt11 invoice passed with the argument
 //Arguments - Bolt11 Invoice [required]
 exports.payInvoice = (req,res) => {
-    console.log('pay initiated...');
+    global.logger.log('pay initiated...');
 
     function connFailed(err) { throw err }
     ln.on('error', connFailed);
@@ -29,10 +29,10 @@ exports.payInvoice = (req,res) => {
         retry_for=retry_for,
         maxdelay = maxdelay,
         exemptfee=exemptfee).then(data => {
-        console.log('pay invoice success');
+        global.logger.log('pay invoice success');
         res.status(201).json(data);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json(err);
     });
     ln.removeListener('error', connFailed);
@@ -42,7 +42,7 @@ exports.payInvoice = (req,res) => {
 //Invoke the 'listpays' command to list all the payments attempted from the node
 //Arguments - Bolt11 invoice [optional]
 exports.listPays = (req,res) => {
-    console.log('listPays initiated...');
+    global.logger.log('listPays initiated...');
 
     function connFailed(err) { throw err }
     ln.on('error', connFailed);
@@ -51,10 +51,10 @@ exports.listPays = (req,res) => {
         var invoice = req.query.invoice;
         //Call the listpays command with invoice
         ln.listpays(invoice).then(data => {
-            console.log('listPays success');
+            global.logger.log('listPays success');
             res.status(200).json(data);
         }).catch(err => {
-            console.warn(err);
+            global.logger.warn(err);
             res.status(500).json({error: err});
         });
         ln.removeListener('error', connFailed);
@@ -63,10 +63,10 @@ exports.listPays = (req,res) => {
     {
         //Call the listpays command without any argument
         ln.listpays().then(data => {
-            console.log('listPays success');
+            global.logger.log('listPays success');
             res.status(200).json(data);
         }).catch(err => {
-            console.warn(err);
+            global.logger.warn(err);
             res.status(500).json({error: err});
         });
         ln.removeListener('error', connFailed);
@@ -77,7 +77,7 @@ exports.listPays = (req,res) => {
 //Invoke the 'listpayments' command to list all the payments attempted from the node
 //Arguments - Bolt11 invoice [optional]
 exports.listPayments = (req,res) => {
-    console.log('listPayments initiated...');
+    global.logger.log('listPayments initiated...');
 
     function connFailed(err) { throw err }
     ln.on('error', connFailed);
@@ -86,10 +86,10 @@ exports.listPayments = (req,res) => {
         var invoice = req.query.invoice;
         //Call the listpayments command with invoice
         ln.listpayments(invoice).then(data => {
-            console.log('listPayments success');
+            global.logger.log('listPayments success');
             res.status(200).json(data);
         }).catch(err => {
-            console.warn(err);
+            global.logger.warn(err);
             res.status(500).json({error: err});
         });
         ln.removeListener('error', connFailed);
@@ -98,10 +98,10 @@ exports.listPayments = (req,res) => {
     {
         //Call the listpayments command without any argument
         ln.listpayments().then(data => {
-            console.log('listPayments success');
+            global.logger.log('listPayments success');
             res.status(200).json(data);
         }).catch(err => {
-            console.warn(err);
+            global.logger.warn(err);
             res.status(500).json({error: err});
         });
         ln.removeListener('error', connFailed);
@@ -112,7 +112,7 @@ exports.listPayments = (req,res) => {
 //Invoke the 'decodepay' command to decode a bolt11 invoice
 //Arguments - Bolt11 invoice [required]
 exports.decodePay = (req,res) => {
-    console.log('decodePay initiated...');
+    global.logger.log('decodePay initiated...');
 
     function connFailed(err) { throw err }
     ln.on('error', connFailed);
@@ -120,10 +120,10 @@ exports.decodePay = (req,res) => {
     var invoice = req.params.invoice;
     //Call the decodepay command
     ln.decodepay(invoice).then(data => {
-        console.log('decodePay success');
+        global.logger.log('decodePay success');
         res.status(200).json(data);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);

--- a/controllers/peers.js
+++ b/controllers/peers.js
@@ -9,11 +9,11 @@ exports.connectPeer = (req,res) => {
 
     //Call the connect command with peer pub key
     ln.connect(req.body.id).then(data => {
-        console.log('id -> '+ data.id);
-        console.log('connectPeer success');
+        global.logger.log('id -> '+ data.id);
+        global.logger.log('connectPeer success');
         res.status(201).json(data);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);
@@ -43,10 +43,10 @@ exports.listPeers = (req,res) => {
         ).then(function(peerList) {
             res.status(200).json(peerList);
           }).catch(err => {
-            console.error(err.error);
+            global.logger.error(err.error);
           });
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);
@@ -64,19 +64,19 @@ exports.disconnectPeer = (req,res) => {
     if(force_flag)
     {
     ln.disconnect(publicKey, force_flag).then(data => {
-        console.log('force disconnectPeer success');
+        global.logger.log('force disconnectPeer success');
         res.status(202).json(data);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     }
     else{
     ln.disconnect(publicKey).then(data => {
-        console.log('disconnectPeer success');
+        global.logger.log('disconnectPeer success');
         res.status(202).json(data);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     }
@@ -90,8 +90,8 @@ getAliasForPeer = (peer) => {
             peer.alias = data.nodes[0] ? data.nodes[0].alias : '';
             resolve(peer);
         }).catch(err => {
-            console.warn('Node lookup for getpeer failed\n');
-            console.warn(err);
+            global.logger.warn('Node lookup for getpeer failed\n');
+            global.logger.warn(err);
             peer.alias = '';
             resolve(peer);
         });

--- a/controllers/withdraw.js
+++ b/controllers/withdraw.js
@@ -4,7 +4,7 @@
 //Invoke the 'withdraw' command to send the on-chain funds out
 //Arguments - Wallet address (required), Amount in Satoshis (required)
 exports.withdraw = (req,res) => {
-    console.log('withdraw initiated...');
+    global.logger.log('withdraw initiated...');
 
     function connFailed(err) { throw err }
     ln.on('error', connFailed);
@@ -20,10 +20,10 @@ exports.withdraw = (req,res) => {
         satoshi=satoshis,
         feerate=feerate,
         minconf=minconf).then(data => {
-        console.log('withdraw success');
+        global.logger.log('withdraw success');
         res.status(201).json(data);
     }).catch(err => {
-        console.warn(err);
+        global.logger.warn(err);
         res.status(500).json({error: err});
     });
     ln.removeListener('error', connFailed);

--- a/package-lock.json
+++ b/package-lock.json
@@ -246,6 +246,11 @@
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
+    "clightningjs": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/clightningjs/-/clightningjs-0.0.2.tgz",
+      "integrity": "sha512-N6JUXrw65KqLFR3W1CoUyxO5Gzzuagubi7bW6s978V3AxHMEt+LdcO7oG19kZN6ZYrUQcwvEF9L01wQQbI3E/g=="
+    },
     "cliui": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "atob": "^2.1.2",
     "body-parser": "^1.19.0",
+    "clightningjs": "0.0.2",
     "error": "^7.0.2",
     "express": "^4.16.4",
     "jsonparse": "^1.3.1",

--- a/plugin.js
+++ b/plugin.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+const Plugin = require('clightningjs');
+
+const restPlugin = new Plugin();
+
+restPlugin.addOption('rest-port', 3001, 'rest plugin listens on this port', 'int');
+restPlugin.addOption('rest-protocol', 'https', 'rest plugin protocol', 'string');
+restPlugin.addOption('rest-execmode', 'production', 'rest exec mode', 'string');
+
+restPlugin.onInit = params => {
+    process.env.LN_PATH = `${params.configuration['lightning-dir']}/${params.configuration['rpc-file']}`
+
+    global.REST_PLUGIN_CONFIG = {
+        PORT: params.options['rest-port'],
+        PROTOCOL: params.options['rest-protocol'],
+        EXECMODE: params.options['rest-execmode'],
+        PLUGIN: restPlugin
+    }
+
+    require('./cl-rest')
+};
+
+restPlugin.start();


### PR DESCRIPTION
This is just to get the conversation started, I think using as a plugin would be beneficial, especially if you are running outside of the default, the plugin knows where to find the rpc file, so configuration easier without needing to launch with env and can be just another entry in the lightning config file, also can be managed from the cli/rpc with the `plugin` command.  

This was a bit more than I expected with the logging, but hopefully straight forward.

I could not get the tests to pass, not on a fresh install, but I don't see how the macaroon header is set in the tests, but I am probably missing something.

Also, if this looks like a good idea, additional readme update required