### PR TITLE
utils: use version 2 macaroons

### DIFF
--- a/utils/bakeMacaroons.js
+++ b/utils/bakeMacaroons.js
@@ -3,12 +3,12 @@ const crypto = require('crypto');
 
 exports.bakeMcrns = () => {
     try {
-    var location = "localhost";
+    var location = "c-lightning";
     var rootKey = crypto.randomBytes(64).toString('hex');
     var identifier = new Date().toString();
 
     //Generate Macaroon
-    var accessMacaroon = macaroon.newMacaroon({identifier:identifier, location:location, rootKey:rootKey});
+    var accessMacaroon = macaroon.newMacaroon({identifier:identifier, location:location, rootKey:rootKey, version: 2});
 
     return [rootKey, accessMacaroon.exportBinary()];
     } catch (error) {


### PR DESCRIPTION
It is advised to use version 2 macaroons since they offer more features.
Also it is usually nice to add some kind of context information to `location` so you know where a macaroon belongs if you find one :-)

Apart from that, the implementation looks good to me :+1: